### PR TITLE
Also execute callback if there has been an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function (opts) {
 		childProcess.execFile(process.execPath, args, function (err, stdout, stderr) {
 			if (err) {
 				this.emit('error', new gutil.PluginError('gulp-ava', stderr || stdout || err));
-				cb(err);
+				cb();
 				return;
 			}
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = function (opts) {
 		childProcess.execFile(process.execPath, args, function (err, stdout, stderr) {
 			if (err) {
 				this.emit('error', new gutil.PluginError('gulp-ava', stderr || stdout || err));
+				cb(err);
 				return;
 			}
 


### PR DESCRIPTION
We had a problem whereby grunt watch would stop because the `ava` stream was not closed if a test failed.

I think this was due to the callback not being called. This has been corrected in this PR.

I'm not super-sure this is the right thing to do so I welcome a discussion.