### PR TITLE
nyc explicitly ref

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (opts) {
 		var args = [BIN].concat(files, '--color', dargs(opts, {excludes: ['nyc']}));
 
 		if (opts.nyc) {
-			var nycBin = resolveCwd('nyc/bin/nyc.js');
+			var nycBin = opts.nyc === true ? resolveCwd('nyc/bin/nyc.js') : opts.nyc;
 
 			if (nycBin) {
 				args.unshift(nycBin);

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ gulp.task('default', () =>
 
 Adheres to AVA [options](https://github.com/avajs/ava#configuration) in package.json. You can also specify options in the plugin as seen above.
 
-You can specify `nyc: true` in the plugin to run AVA with [`nyc`](https://github.com/istanbuljs/nyc). You must have `nyc` as a devDependency. `nyc` [options](https://github.com/istanbuljs/nyc#configuring-nyc) can be defined in package.json.
+You can specify `nyc: true` in the plugin to run AVA with [`nyc`](https://github.com/istanbuljs/nyc) or `nyc: "path/to/nyc/bin/nyc.js"` to explicitly refer to the `nyc` CLI. You must have `nyc` as a devDependency. `nyc` [options](https://github.com/istanbuljs/nyc#configuring-nyc) can be defined in package.json.
 
 
 ## License


### PR DESCRIPTION
In case `gulp-ava` in used from a dependency of a project the method `resolveCwd` wont be able to find `nyc.

Allow to specify `nyc` path by the given option:
```
{
  "nyc": "custom/path/to/nyc/bin/nyc.js"
}
```