### PR TITLE
Emitting an 'end' event when all tests completed

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,10 @@ module.exports = function (opts) {
 				return;
 			}
 
+			
 			cb();
 			gutil.log('gulp-ava:\n' + stderr + stdout);
+			this.emit('end');
 		}.bind(this));
 	});
 };

--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ module.exports = function (opts) {
 				return;
 			}
 
-			
 			cb();
 			gutil.log('gulp-ava:\n' + stderr + stdout);
 			this.emit('end');


### PR DESCRIPTION

Emitting an 'end' event conforms with readable streams, as a valid companion to other events such as 'error' that are already supported in the plugin.

Emitting the 'end' event is particularly useful for gulp tasks that integrate with `gulp-ava` and would need to subscribe to the case where all test completed running.

Example code:
```
gulp.task('ava', function() {
  gulp.src(testFiles)
    .pipe(plugins.ava({verbose: true}))
    .on('end', function() {
      console.log('Tests Completed');
    });
});
```