### PR TITLE
Increasing the max buffer size for long-running tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = opts => {
 			}
 		}
 
-		childProcess.execFile(process.execPath, args, (err, stdout, stderr) => {
+		childProcess.execFile(process.execPath, args, {maxBuffer: 1024000}, (err, stdout, stderr) => {
 			if (err) {
 				this.emit('error', new gutil.PluginError('gulp-ava', stderr || stdout || err));
 				cb();


### PR DESCRIPTION
Quick fix for issue #19, as suggested by @sindresorhus. This would fix our failing CI test suite and get us back on track again @a-lucas.

---

Fixes #19 