### PR TITLE
Add environment option

### DIFF
--- a/fixture4.js
+++ b/fixture4.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('env', t => {
+	t.is(process.env.NODE_ENV, 'foo');
+});

--- a/index.js
+++ b/index.js
@@ -43,10 +43,12 @@ module.exports = opts => {
 			args.unshift(nycBin);
 		}
 
-		const ps = execa(process.execPath, args, {
+		const execOpts = Object.assign({
 			// TODO: Remove this when `execa` supports a `buffer: false` option
 			maxBuffer: HUNDRED_MEGABYTES
-		});
+		}, opts.env && {env: opts.env});
+
+		const ps = execa(process.execPath, args, execOpts);
 
 		if (!opts.silent) {
 			ps.stdout.pipe(process.stdout);

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,12 @@ Default: `false`
 
 Run AVA with [`nyc`](https://github.com/istanbuljs/nyc). You must have `nyc` as a devDependency. `nyc` [options](https://github.com/istanbuljs/nyc#configuring-nyc) can be defined in package.json.
 
+#### env
+
+Type: `Object`<br>
+Default: `process.env`
+
+Environment variables for the AVA process. Extends `process.env`.
 
 ## License
 


### PR DESCRIPTION
Adds an `env` option to the function such that you can set the `NODE_ENV` to `test`