### PR TITLE
Fix for issue causing subprocess to never end

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = options => {
 			args.unshift(nycBin);
 		}
 
-		const subprocess = execa(process.execPath, args, {buffer: false});
+		const subprocess = execa(process.execPath, args, {buffer: true});
 
 		if (!options.silent) {
 			subprocess.stdout.pipe(process.stdout);


### PR DESCRIPTION
fixes #23 and #29.

For some reason, if `buffer` is set to `false`, the `await subprocess` call never ends, no matter if the test passes or not.

See #29 for steps to reproduce in this very repo.