### PR TITLE
Update `execa` to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"dependencies": {
 		"ava": "^2.4.0",
 		"dargs": "^7.0.0",
-		"execa": "^2.0.4",
+		"execa": "^3.0.0",
 		"fancy-log": "^1.3.3",
 		"plugin-error": "^1.0.1",
 		"resolve-cwd": "^3.0.0",


### PR DESCRIPTION
Fixes #23 and #29 in a much better way than #30, now that `execa` `3.0.0` is out.

Tests have been run, and it seems to work just fine.